### PR TITLE
Remove unused align-middle, changed cross cursor

### DIFF
--- a/header-banner/header-banner-green.html
+++ b/header-banner/header-banner-green.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="res/css/styles.css">
 </head>
 <body>
-  <div class="relative top-0 flex justify-between w-full px-2 py-2 font-nunito overflow-hidden text-white align-middle bg-green-500 md:px-6 md:py-3">
+  <div class="relative top-0 flex justify-between w-full px-2 py-2 font-nunito overflow-hidden text-white bg-green-500 md:px-6 md:py-3">
     <div class="h-full">
       <svg class="w-10 h-10 p-2 mx-1 bg-green-700 md:mx-3 rounded-md" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
@@ -15,11 +15,11 @@
       
     </div>
     <div class="flex items-center justify-between w-full">
-      <p class="py-0 mx-2 text-xs align-middle sm:text-base font-semibold md:py-2">Big news! We're excited to announce a brand new product.</p>
+      <p class="py-0 mx-2 text-xs sm:text-base font-semibold md:py-2">Big news! We're excited to announce a brand new product.</p>
       <button class="w-24 h-8 mx-2 text-xs font-medium text-center text-green-700 bg-white sm:h-full sm:mx-3 sm:w-32 sm:text-sm rounded-md" href="#">Learn more</button>
     </div>
     <div class="mx-0">
-      <svg class="w-5 h-full" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg class="w-5 h-full cursor-pointer" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
       </svg>
     </div>

--- a/header-banner/header-banner-indigo.html
+++ b/header-banner/header-banner-indigo.html
@@ -7,18 +7,18 @@
   <link rel="stylesheet" href="res/css/styles.css">
 </head>
 <body>
-  <div class="relative top-0 flex justify-between w-full px-2 py-2 font-nunito overflow-hidden text-white align-middle bg-indigo-500 md:px-6 md:py-3">
+  <div class="relative top-0 flex justify-between w-full px-2 py-2 font-nunito overflow-hidden text-white bg-indigo-500 md:px-6 md:py-3">
     <div class="h-full">
       <svg class="w-10 h-10 p-2 mx-1 bg-indigo-700 md:mx-3 rounded-md" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
       </svg>
     </div>
     <div class="flex items-center justify-between w-full">
-      <p class="py-0 mx-2 text-xs align-middle sm:text-base font-semibold md:py-2">Big news! We're excited to announce a brand new product.</p>
+      <p class="py-0 mx-2 text-xs sm:text-base font-semibold md:py-2">Big news! We're excited to announce a brand new product.</p>
       <button class="w-24 h-8 mx-2 text-xs font-semibold text-center text-indigo-700 bg-white sm:h-full sm:mx-3 sm:w-32 sm:text-sm rounded-md" href="#">Learn more</button>
     </div>
     <div class="mx-0">
-      <svg class="w-5 h-full" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg class="w-5 h-full cursor-pointer" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
       </svg>
     </div>

--- a/header-banner/header-banner-red.html
+++ b/header-banner/header-banner-red.html
@@ -7,18 +7,18 @@
   <link rel="stylesheet" href="res/css/styles.css">
 </head>
 <body>
-  <div class="relative top-0 flex justify-between w-full px-2 py-2 font-nunito overflow-hidden text-white align-middle bg-red-500 md:px-6 md:py-3">
+  <div class="relative top-0 flex justify-between w-full px-2 py-2 font-nunito overflow-hidden text-white bg-red-500 md:px-6 md:py-3">
     <div class="h-full">
       <svg class="w-10 h-10 p-2 mx-1 bg-red-700 md:mx-3 rounded-md" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
       </svg>
     </div>
     <div class="flex items-center justify-between w-full">
-      <p class="py-0 mx-2 text-xs align-middle sm:text-base font-semibold md:py-2">Big news! We're excited to announce a brand new product.</p>
+      <p class="py-0 mx-2 text-xs sm:text-base font-semibold md:py-2">Big news! We're excited to announce a brand new product.</p>
       <button class="w-24 h-8 mx-2 text-xs font-semibold text-center text-red-700 bg-white sm:h-full sm:mx-3 sm:w-32 sm:text-sm rounded-md" href="#">Learn more</button>
     </div>
     <div class="mx-0">
-      <svg class="w-5 h-full" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <svg class="w-5 h-full cursor-pointer" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
       </svg>
     </div>


### PR DESCRIPTION
Removed unused align-middle. see:
vertical-align has no effect on this element since it’s not an inline or table-cell element.
Try adding display:inline or display:table-cell. <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align">Learn more</a>

Added cursor to cross svg

See it in action! https://play.tailwindcss.com/UhHDWi6D1Y